### PR TITLE
fix: improve how to get security groups, subnets and tags from machines

### DIFF
--- a/ansible/playbooks/create-gpu-machine-set.yaml
+++ b/ansible/playbooks/create-gpu-machine-set.yaml
@@ -56,6 +56,9 @@
         clusterId: "{{ infraInfo.resources[0].status.infrastructureName }}"
         instanceAmi: "{{ machines.resources[0].spec.providerSpec.value.ami.id }}"
         cacheable: no
+        securityGroups: "{{ machines.resources[0].spec.providerSpec.value.securityGroups }}"
+        subnets: "{{ machines.resources[0].spec.providerSpec.value.subnet }}"
+        tags: "{{ machines.resources[0].spec.providerSpec.value.tags }}"
 
     - name: "[create-gpu-machine-set] Generate machineset"
       ansible.builtin.template:

--- a/ansible/playbooks/templates/gpu-machine-sets.j2
+++ b/ansible/playbooks/templates/gpu-machine-sets.j2
@@ -58,20 +58,8 @@ spec:
           placement:
             availabilityZone: {{ cloudAvailabilityZone }}
             region: {{ cloudRegion }}
-          securityGroups:
-          - filters:
-            - name: tag:Name
-              values:
-              - {{ clusterId }}-worker-sg
-          subnet:
-            filters:
-            - name: tag:Name
-              values:
-              - {{ clusterId }}-private-{{ cloudAvailabilityZone }}
-          tags:
-          - name: kubernetes.io/cluster/{{ clusterId }}
-            value: owned
-          - name: owner
-            value: claudiol
+          securityGroups: {{ securityGroups | to_json }}
+          subnet: {{ subnets | to_json }}
+          tags: {{ tags | to_json }}
           userDataSecret:
             name: worker-user-data


### PR DESCRIPTION
Users can customize the security groups, subnets and tags, this allows to
use the machines that already exists and get the security groups, subnets
and tags to deploy avoiding heuristics that could not be true.