### PR TITLE
fix: add missing field to passwd entry

### DIFF
--- a/common/scripts/pattern-util.sh
+++ b/common/scripts/pattern-util.sh
@@ -38,7 +38,7 @@ else
     MYNAME=$(id -n -u)
     MYUID=$(id -u)
     MYGID=$(id -g)
-    PODMAN_ARGS="--passwd-entry ${MYNAME}:x:${MYUID}:${MYGID}:/pattern-home:/bin/bash --user ${MYUID}:${MYGID} --userns keep-id:uid=${MYUID},gid=${MYGID}"
+    PODMAN_ARGS="--passwd-entry ${MYNAME}:x:${MYUID}:${MYGID}::/pattern-home:/bin/bash --user ${MYUID}:${MYGID} --userns keep-id:uid=${MYUID},gid=${MYGID}"
 fi
 
 if [ -n "$KUBECONFIG" ]; then


### PR DESCRIPTION
The the passwd entry was missing the `user info` field and this was leading
to assume `/bin/bash` as the home directory, so the ssh configuration was
being picked up from `/bin/bash/.ssh/config` which fails.