### PR TITLE
fix: switch nvidia operator to channel v24.6

### DIFF
--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -21,7 +21,7 @@ clusterGroup:
     nvidia:
       name: gpu-operator-certified
       namespace: nvidia-gpu-operator
-      channel: v23.6
+      channel: v24.6
       source: certified-operators
 
   projects:


### PR DESCRIPTION
The nvidia operator using a channel to the fixed versions fails when new
 versions of the drivers are required for the AMI images, but the stable
 channels brings some errors when is used to better to keep the fixed version
