### PR TITLE
chore: set Grafana versions for OpenShift >= 4.11

### DIFF
--- a/ansible/playbooks/create-gpu-machine-set.yaml
+++ b/ansible/playbooks/create-gpu-machine-set.yaml
@@ -56,6 +56,9 @@
         clusterId: "{{ infraInfo.resources[0].status.infrastructureName }}"
         instanceAmi: "{{ machines.resources[0].spec.providerSpec.value.ami.id }}"
         cacheable: no
+        securityGroups: "{{ machines.resources[0].spec.providerSpec.value.securityGroups }}"
+        subnets: "{{ machines.resources[0].spec.providerSpec.value.subnet }}"
+        tags: "{{ machines.resources[0].spec.providerSpec.value.tags }}"
 
     - name: "[create-gpu-machine-set] Generate machineset"
       ansible.builtin.template:

--- a/ansible/playbooks/templates/gpu-machine-sets.j2
+++ b/ansible/playbooks/templates/gpu-machine-sets.j2
@@ -58,20 +58,8 @@ spec:
           placement:
             availabilityZone: {{ cloudAvailabilityZone }}
             region: {{ cloudRegion }}
-          securityGroups:
-          - filters:
-            - name: tag:Name
-              values:
-              - {{ clusterId }}-worker-sg
-          subnet:
-            filters:
-            - name: tag:Name
-              values:
-              - {{ clusterId }}-private-{{ cloudAvailabilityZone }}
-          tags:
-          - name: kubernetes.io/cluster/{{ clusterId }}
-            value: owned
-          - name: owner
-            value: claudiol
+          securityGroups: {{ securityGroups | to_json }}
+          subnet: {{ subnets | to_json }}
+          tags: {{ tags | to_json }}
           userDataSecret:
             name: worker-user-data

--- a/charts/all/llm-monitoring/kustomize/base/grafana/ai-llm-grafana.yaml
+++ b/charts/all/llm-monitoring/kustomize/base/grafana/ai-llm-grafana.yaml
@@ -1,4 +1,4 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana
 metadata:
   annotations:
@@ -7,15 +7,15 @@ metadata:
 spec:
   config:
     auth:
-      disable_login_form: false
-      disable_signout_menu: false
+      disable_login_form: "false"
+      disable_signout_menu: "false"
     auth.anonymous:
-      enabled: true
+      enabled: "true"
     log:
       level: error
       mode: console
     log.frontend:
-      enabled: true
+      enabled: "true"
   dashboardLabelSelector:
     - matchExpressions:
         - key: app

--- a/charts/all/llm-monitoring/kustomize/base/grafana/prometheus-datasource.yaml
+++ b/charts/all/llm-monitoring/kustomize/base/grafana/prometheus-datasource.yaml
@@ -1,4 +1,4 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDataSource
 metadata:
   annotations:

--- a/charts/all/llm-monitoring/kustomize/base/grafanadashboard/ai-llm-dashboard.yaml
+++ b/charts/all/llm-monitoring/kustomize/base/grafanadashboard/ai-llm-dashboard.yaml
@@ -1,4 +1,4 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   annotations:

--- a/charts/all/llm-monitoring/kustomize/base/operators.coreos.com/subscriptions/grafana/grafana.yaml
+++ b/charts/all/llm-monitoring/kustomize/base/operators.coreos.com/subscriptions/grafana/grafana.yaml
@@ -3,9 +3,8 @@ kind: Subscription
 metadata:
   name: grafana-operator
 spec:
-  channel: v4
+  channel: v5
   installPlanApproval: Automatic
   name: grafana-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: grafana-operator.v4.10.1

--- a/common/scripts/pattern-util.sh
+++ b/common/scripts/pattern-util.sh
@@ -38,7 +38,7 @@ else
     MYNAME=$(id -n -u)
     MYUID=$(id -u)
     MYGID=$(id -g)
-    PODMAN_ARGS="--passwd-entry ${MYNAME}:x:${MYUID}:${MYGID}:/pattern-home:/bin/bash --user ${MYUID}:${MYGID} --userns keep-id:uid=${MYUID},gid=${MYGID}"
+    PODMAN_ARGS="--passwd-entry ${MYNAME}:x:${MYUID}:${MYGID}::/pattern-home:/bin/bash --user ${MYUID}:${MYGID} --userns keep-id:uid=${MYUID},gid=${MYGID}"
 fi
 
 if [ -n "$KUBECONFIG" ]; then

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -21,7 +21,7 @@ clusterGroup:
     nvidia:
       name: gpu-operator-certified
       namespace: nvidia-gpu-operator
-      channel: v23.6
+      channel: stable
       source: certified-operators
 
   projects:


### PR DESCRIPTION
The previous channel used v4 is not available at least on OpenShift 4.16
but the channel v5 is available on all versions of OpenShift since 4.11,
also, use the latest version on that channel by default.
