### PR TITLE
chore: set Grafana versions for OpenShift >= 4.11

### DIFF
--- a/charts/all/llm-monitoring/kustomize/base/grafana/ai-llm-grafana.yaml
+++ b/charts/all/llm-monitoring/kustomize/base/grafana/ai-llm-grafana.yaml
@@ -1,28 +1,25 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    dashboards: "grafana"
   name: ai-llm-grafana
 spec:
   config:
     auth:
-      disable_login_form: false
-      disable_signout_menu: false
+      disable_login_form: "false"
+      disable_signout_menu: "false"
     auth.anonymous:
-      enabled: true
+      enabled: "true"
     log:
       level: error
       mode: console
     log.frontend:
-      enabled: true
-  dashboardLabelSelector:
-    - matchExpressions:
-        - key: app
-          operator: In
-          values:
-            - grafana
-  ingress:
-    enabled: true
-    path: /
-    pathType: Prefix
+      enabled: "true"
+# The ingress field in this format exist only for Grafana operator < 5
+#  ingress:
+#    enabled: true
+#    path: /
+#    pathType: Prefix

--- a/charts/all/llm-monitoring/kustomize/base/grafana/prometheus-datasource.yaml
+++ b/charts/all/llm-monitoring/kustomize/base/grafana/prometheus-datasource.yaml
@@ -1,19 +1,21 @@
-apiVersion: integreatly.org/v1alpha1
-kind: GrafanaDataSource
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: prometheus-datasource
 spec:
-  datasources:
-    - access: proxy
-      editable: true
-      secureJsonData: {}
-      name: Prometheus
-      url: 'prometheus-operated:9090'
-      jsonData:
-        timeInterval: 5s
-      isDefault: true
-      version: 1
-      type: prometheus
-  name: prometheus.yaml
+  datasource:
+    access: proxy
+    editable: true
+    secureJsonData: {}
+    name: Prometheus
+    url: 'prometheus-operated:9090'
+    jsonData:
+      timeInterval: 5s
+    isDefault: true
+    version: 1
+    type: prometheus
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"

--- a/charts/all/llm-monitoring/kustomize/base/grafanadashboard/ai-llm-dashboard.yaml
+++ b/charts/all/llm-monitoring/kustomize/base/grafanadashboard/ai-llm-dashboard.yaml
@@ -1,4 +1,4 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   annotations:
@@ -7,6 +7,9 @@ metadata:
   labels:
     app: grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
   json: |
     {
       "annotations": {

--- a/charts/all/llm-monitoring/kustomize/base/operators.coreos.com/subscriptions/grafana/grafana.yaml
+++ b/charts/all/llm-monitoring/kustomize/base/operators.coreos.com/subscriptions/grafana/grafana.yaml
@@ -3,9 +3,8 @@ kind: Subscription
 metadata:
   name: grafana-operator
 spec:
-  channel: v4
+  channel: v5
   installPlanApproval: Automatic
   name: grafana-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: grafana-operator.v4.10.1


### PR DESCRIPTION
The previous channel used v4 is not available at least on OpenShift 4.16
 but the channel v5 is available on all versions of OpenShift since 4.11,
 also, use the latest version on that channel by default.