### PR TITLE
chore: add sync-wave to the Subscription object

### DIFF
--- a/charts/all/rag-llm/charts/edb-operator/templates/subscription.yaml
+++ b/charts/all/rag-llm/charts/edb-operator/templates/subscription.yaml
@@ -4,6 +4,8 @@ kind: Subscription
 metadata:
   name: {{ .Values.subscription.name }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-100"
 spec:
   channel: {{ .Values.subscription.channel }}
   installPlanApproval: {{ .Values.subscription.installPlanApproval }}

--- a/charts/all/rag-llm/charts/edb-operator/values.yaml
+++ b/charts/all/rag-llm/charts/edb-operator/values.yaml
@@ -1,6 +1,6 @@
 subscription:
   name: cloud-native-postgresql
-  channel: stable-v1.22
+  channel: stable-v1.23
   installPlanApproval: Automatic
   source: certified-operators
   sourceNamespace: openshift-marketplace

--- a/charts/all/rag-llm/charts/edb/templates/cluster.yaml
+++ b/charts/all/rag-llm/charts/edb/templates/cluster.yaml
@@ -3,6 +3,9 @@ apiVersion: postgresql.k8s.enterprisedb.io/v1
 kind: Cluster
 metadata:
   name: vectordb
+  annotations:
+    argocd.argoproj.io/sync-wave: "50"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   logLevel: info
   startDelay: 3600

--- a/charts/all/rag-llm/charts/edb/templates/edb-pg-extension-job.yaml
+++ b/charts/all/rag-llm/charts/edb/templates/edb-pg-extension-job.yaml
@@ -5,6 +5,8 @@ metadata:
   name: edb-pg-extension-job
   labels:
     component: edb-pg-extension-job
+  annotations:
+    argocd.argoproj.io/sync-wave: "50"
 spec:
   parallelism: 1
   completions: 1

--- a/charts/all/rag-llm/charts/edb/templates/postgres-rb.yaml
+++ b/charts/all/rag-llm/charts/edb/templates/postgres-rb.yaml
@@ -3,6 +3,8 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: postgres-rb
+  annotations:
+    argocd.argoproj.io/sync-wave: "50"
 subjects:
   - kind: ServiceAccount
     name: postgres-service-account

--- a/charts/all/rag-llm/charts/edb/templates/postgres-service-account.yaml
+++ b/charts/all/rag-llm/charts/edb/templates/postgres-service-account.yaml
@@ -3,4 +3,6 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: postgres-service-account
+  annotations:
+    argocd.argoproj.io/sync-wave: "50"
 {{- end }}

--- a/charts/all/rag-llm/charts/edb/templates/postgres-service-role.yaml
+++ b/charts/all/rag-llm/charts/edb/templates/postgres-service-role.yaml
@@ -3,6 +3,8 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: postgres-service-role
+  annotations:
+    argocd.argoproj.io/sync-wave: "50"
 rules:
   - verbs:
       - get

--- a/charts/all/rag-llm/templates/configmap.yaml
+++ b/charts/all/rag-llm/templates/configmap.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: providerconfig
+  annotations:
+    argocd.argoproj.io/sync-wave: "50"
 data:
   config.yaml: |-
     {{- tpl ($.Files.Get "files/config.yaml") . | nindent 4 }}
@@ -12,6 +14,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: redis-schema
+  annotations:
+    argocd.argoproj.io/sync-wave: "50"
 data:
   redis_schema.yaml: |-
     {{- tpl ($.Files.Get "files/redis_schema.yaml") . | nindent 4 }}

--- a/charts/all/rag-llm/templates/deployment.yaml
+++ b/charts/all/rag-llm/templates/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: ui-multiprovider-rag-redis
   labels:
     {{- include "rag-llm.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "50"
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/all/rag-llm/templates/hpa.yaml
+++ b/charts/all/rag-llm/templates/hpa.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "rag-llm.fullname" . }}
   labels:
     {{- include "rag-llm.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "50"
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/all/rag-llm/templates/populate-vectordb-job.yaml
+++ b/charts/all/rag-llm/templates/populate-vectordb-job.yaml
@@ -4,6 +4,8 @@ metadata:
   name:  populate-vectordb-{{ include "rag-llm.fullname" . }}
   labels:
     {{- include "rag-llm.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "50"
 spec:
 {{- if eq .Values.global.db.type "PGVECTOR" }}
   ttlSecondsAfterFinished: 100

--- a/charts/all/rag-llm/templates/route.yaml
+++ b/charts/all/rag-llm/templates/route.yaml
@@ -5,6 +5,8 @@ metadata:
   name: llm-ui
   labels:
     {{- include "rag-llm.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "50"
 spec:
 #  host: {{ .Values.route.path }}
   port:

--- a/charts/all/rag-llm/templates/service.yaml
+++ b/charts/all/rag-llm/templates/service.yaml
@@ -4,6 +4,8 @@ metadata:
   name: ui-multiprovider-rag-redis
   labels:
     {{- include "rag-llm.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "50"
 spec:
   type: {{ .Values.service.type }}
   clusterIP: None

--- a/charts/all/rag-llm/templates/serviceaccount.yaml
+++ b/charts/all/rag-llm/templates/serviceaccount.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "rag-llm.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
+    argocd.argoproj.io/sync-wave: "50"
     {{- toYaml . | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automount }}


### PR DESCRIPTION
Now the subscription object will have precedence over all the apps in the Application creating the subscription first.
Also, the cluster object will skip validation since the CRDs may not exists