### PR TITLE
chore: fix argocd hook and remove ttl for populate job

### DIFF
--- a/charts/all/rag-llm/templates/populate-vectordb-job.yaml
+++ b/charts/all/rag-llm/templates/populate-vectordb-job.yaml
@@ -2,14 +2,12 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name:  populate-vectordb-{{ include "rag-llm.fullname" . }}
-  labels:
+  annotations:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
+  labels:
     {{- include "rag-llm.labels" . | nindent 4 }}
 spec:
-{{- if eq .Values.global.db.type "PGVECTOR" }}
-  ttlSecondsAfterFinished: 100
-{{- end }}
   template:
     spec:
     {{- if .Values.populateDbJob.imagePullSecrets }}


### PR DESCRIPTION
The hook for PreSync was set as a label and not as annotation, also remove the TTL for the
job since using the hook the ttl is not needed