### PR TITLE
Expand supported regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ OpenShift to generate project proposals for specific Red Hat products.
 ## Pre-requisites
 
 - Podman
-- Red Hat Openshift cluster running in AWS. Supported regions are us-west-2 and us-east-1.
+- Red Hat Openshift cluster running in AWS. Supported regions are : us-east-1 us-east-2 us-west-1 us-west-2 ca-central-1 sa-east-1 eu-west-1 eu-west-2 eu-west-3 eu-central-1 eu-north-1 ap-northeast-1 ap-northeast-2 ap-northeast-3 ap-southeast-1 ap-southeast-2 ap-south-1.
 - GPU Node to run Hugging Face Text Generation Inference server on Red Hat OpenShift cluster.
 - Create a fork of the [rag-llm-gitops](https://github.com/validatedpatterns/rag-llm-gitops.git) git repository.
 

--- a/ansible/playbooks/create-gpu-machine-set.yaml
+++ b/ansible/playbooks/create-gpu-machine-set.yaml
@@ -8,7 +8,21 @@
     usable_regions:
       - us-east-1
       - us-east-2
+      - us-west-1
       - us-west-2
+      - ca-central-1
+      - sa-east-1
+      - eu-west-1
+      - eu-west-2
+      - eu-west-3
+      - eu-central-1
+      - eu-north-1
+      - ap-northeast-1
+      - ap-northeast-2
+      - ap-northeast-3
+      - ap-southeast-1
+      - ap-southeast-2
+      - ap-south-1
   tasks:
     - name: "[create-gpu-machine-set] Get the infrai-id for the cluster"
       kubernetes.core.k8s_info:


### PR DESCRIPTION
Tested with the following:

    #!/bin/bash

    regions="us-east-1 us-east-2 us-west-1 us-west-2 ca-central-1 ca-west-1 us-gov-east-1 us-gov-west-1 mx-central-1 sa-east-1 eu-west-1 eu-west-2 eu-west-3 eu-central-1 eu-north-1 eu-south-1 eu-south-2 eu-central-2 il-central-1 me-south-1 me-central-1 af-south-1 ap-northeast-1 ap-northeast-2 ap-northeast-3 ap-southeast-1 ap-southeast-2 ap-southeast-3 ap-southeast-4 ap-east-1 ap-south-1 ap-south-2 ap-southeast-5 ap-southeast-7 cn-north-1 cn-northwest-1"

    export AWS_PAGER=
    for i in ${regions}; do
        out=$(aws ec2 describe-instance-type-offerings --location-type region --filters "Name=instance-type,Values=g5.2xlarge" --region "${i}" 2>&1)
        ret=$?
        if [ $ret -eq 0 ]; then
          echo -n "${i} "
        fi
    done
    echo ""

Got:

us-east-1 us-east-2 us-west-1 us-west-2 ca-central-1 sa-east-1 eu-west-1 eu-west-2 eu-west-3 eu-central-1 eu-north-1 ap-northeast-1 ap-northeast-2 ap-northeast-3 ap-southeast-1 ap-southeast-2 ap-south-1
