### PR TITLE
Drop version from GrafanaDataSource

### DIFF
--- a/charts/all/llm-monitoring/kustomize/base/grafana/prometheus-datasource.yaml
+++ b/charts/all/llm-monitoring/kustomize/base/grafana/prometheus-datasource.yaml
@@ -14,7 +14,6 @@ spec:
     jsonData:
       timeInterval: 5s
     isDefault: true
-    version: 1
     type: prometheus
   instanceSelector:
     matchLabels:


### PR DESCRIPTION
There is no such field in the operator's CRD and it causes argo to be
outofsync.

$ grep -B5 -ir version: config/crd/bases/grafana.integreatly.org_grafanadatasources.yaml
---
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  annotations:
    controller-gen.kubebuilder.io/version: v0.16.3
--
    name: v1beta1
    schema:
      openAPIV3Schema:
        description: GrafanaDatasource is the Schema for the grafanadatasources API
        properties:
          apiVersion:
--
                description: plugins
                items:
                  properties:
                    name:
                      type: string
                    version:

$ git lg --grep version config/crd/bases/grafana.integreatly.org_grafanadatasources.yaml
$
