### PR TITLE
Added Elastic as vector DB to RAG LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Alternatiely, follow the [instructions](./GPU_provisioning.md) to manually insta
 
 ### Deploy application
 
-***Note:**: This pattern supports two types of vector databases, EDB Postgres for Kubernetes and Redis. By default the pattern will deploy EDB Postgres for Kubernetes as a vector DB. To deploy Redis, change the global.db.type to REDIS in [values-global.yaml](./values-global.yaml).
+***Note:**: This pattern supports three types of vector databases, EDB Postgres for Kubernetes, Elasticsearch and Redis. By default the pattern will deploy EDB Postgres for Kubernetes as a vector DB. To deploy Redis, change the global.db.type to REDIS in [values-global.yaml](./values-global.yaml).
 
 ```yaml
 ---
@@ -161,10 +161,10 @@ global:
     useCSV: false
     syncPolicy: Automatic
     installPlanApproval: Automatic
-# Possible value for db.type = [REDIS, EDB]
+# Possible value for db.type = [REDIS, EDB, ELASTIC]
   db:
     index: docs
-    type: EDB  # <--- Default is EDB, Change the db type to REDIS for Redis deployment
+    type: EDB  # <--- Default is EDB, Change the db type to REDIS for Redis deployment or ELASTIC for Elasticsearch
 main:
   clusterGroupName: hub
   multiSourceConfig:

--- a/charts/all/llm-monitoring/kustomize/base/grafanadashboard/ai-llm-dashboard.yaml
+++ b/charts/all/llm-monitoring/kustomize/base/grafanadashboard/ai-llm-dashboard.yaml
@@ -16,7 +16,10 @@ spec:
         "list": [
           {
             "builtIn": 1,
-            "datasource": "-- Grafana --",
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
             "enable": true,
             "hide": true,
             "iconColor": "rgba(0, 211, 255, 1)",
@@ -26,15 +29,13 @@ spec:
         ]
       },
       "editable": true,
-      "gnetId": null,
+      "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
       "id": 2,
-      "iteration": 1705107864294,
       "links": [],
       "panels": [
         {
           "collapsed": false,
-          "datasource": null,
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -47,7 +48,7 @@ spec:
           "type": "row"
         },
         {
-          "datasource": null,
+          "datasource": "Prometheus",
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -75,7 +76,7 @@ spec:
           },
           "gridPos": {
             "h": 8,
-            "w": 12,
+            "w": 24,
             "x": 0,
             "y": 1
           },
@@ -83,6 +84,16 @@ spec:
           "maxPerRow": 2,
           "options": {
             "displayMode": "gradient",
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "maxVizHeight": 300,
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "auto",
             "orientation": "auto",
             "reduceOptions": {
               "calcs": [
@@ -92,20 +103,16 @@ spec:
               "values": false
             },
             "showUnfilled": true,
-            "text": {}
+            "sizing": "auto",
+            "text": {},
+            "valueMode": "color"
           },
-          "pluginVersion": "7.5.17",
+          "pluginVersion": "11.3.0",
           "repeat": "ModelID",
           "repeatDirection": "h",
-          "scopedVars": {
-            "ModelID": {
-              "selected": false,
-              "text": "mistral-community/Mistral-7B-v0.2",
-              "value": "mistral-community/Mistral-7B-v0.2"
-            }
-          },
           "targets": [
             {
+              "datasource": "Prometheus",
               "exemplar": true,
               "expr": "sum(feedback_stars_total{namespace=\"$namespace\", model_id=\"${ModelID:raw}\"}) by (stars)",
               "format": "time_series",
@@ -116,85 +123,10 @@ spec:
             }
           ],
           "title": "$ModelID - RATINGS",
-          "transformations": [],
           "type": "bargauge"
         },
         {
-          "datasource": null,
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "max": 50,
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 1
-          },
-          "id": 21,
-          "maxPerRow": 2,
-          "options": {
-            "displayMode": "gradient",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showUnfilled": true,
-            "text": {}
-          },
-          "pluginVersion": "7.5.17",
-          "repeatDirection": "h",
-          "repeatIteration": 1705107864294,
-          "repeatPanelId": 2,
-          "scopedVars": {
-            "ModelID": {
-              "selected": false,
-              "text": "ibm-granite/granite-3.1-8b-instruct",
-              "value": "ibm-granite/granite-3.1-8b-instruct"
-            }
-          },
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "sum(feedback_stars_total{namespace=\"$namespace\", model_id=\"${ModelID:raw}\"}) by (stars)",
-              "format": "time_series",
-              "instant": false,
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "$ModelID - RATINGS",
-          "transformations": [],
-          "type": "bargauge"
-        },
-        {
-          "datasource": null,
+          "datasource": "Prometheus",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -225,7 +157,7 @@ spec:
           },
           "gridPos": {
             "h": 8,
-            "w": 12,
+            "w": 24,
             "x": 0,
             "y": 9
           },
@@ -246,15 +178,9 @@ spec:
           "pluginVersion": "7.5.17",
           "repeat": "ModelID",
           "repeatDirection": "h",
-          "scopedVars": {
-            "ModelID": {
-              "selected": false,
-              "text": "mistral-community/Mistral-7B-v0.2",
-              "value": "mistral-community/Mistral-7B-v0.2"
-            }
-          },
           "targets": [
             {
+              "datasource": "Prometheus",
               "exemplar": true,
               "expr": "(sum((feedback_stars_total{namespace=\"$namespace\", stars=\"1\", model_id=\"${ModelID:raw}\"} or on() vector(0))* 1) + sum((feedback_stars_total{namespace=\"$namespace\", stars=\"2\", model_id=\"${ModelID:raw}\"} or on() vector(0)) * 2) +\nsum((feedback_stars_total{namespace=\"$namespace\", stars=\"3\", model_id=\"${ModelID:raw}\"} or on() vector(0)) * 3) + sum((feedback_stars_total{namespace=\"$namespace\", stars=\"4\", model_id=\"${ModelID:raw}\"} or on() vector(0)) * 4) +\nsum((feedback_stars_total{namespace=\"$namespace\", stars=\"5\", model_id=\"${ModelID:raw}\"} or on() vector(0)) * 5)) \n/\n(sum(feedback_stars_total{namespace=\"$namespace\", stars=\"1\", model_id=\"${ModelID:raw}\"} or on() vector(0)) + sum(feedback_stars_total{namespace=\"$namespace\", stars=\"2\", model_id=\"${ModelID:raw}\"} or on() vector(0)) + sum(feedback_stars_total{namespace=\"$namespace\", stars=\"3\", model_id=\"${ModelID:raw}\"} or on() vector(0)) + sum(feedback_stars_total{namespace=\"$namespace\", stars=\"4\", model_id=\"${ModelID:raw}\"} or on() vector(0)) + sum(feedback_stars_total{namespace=\"$namespace\", stars=\"5\", model_id=\"${ModelID:raw}\"} or on() vector(0)))",
               "format": "time_series",
@@ -264,90 +190,11 @@ spec:
               "refId": "A"
             }
           ],
-          "timeFrom": null,
-          "timeShift": null,
           "title": "$ModelID - AVERAGE RATING",
           "type": "gauge"
         },
         {
-          "datasource": null,
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "max": 5,
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 2
-                  },
-                  {
-                    "color": "green",
-                    "value": 3.5
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 9
-          },
-          "id": 22,
-          "maxPerRow": 2,
-          "options": {
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true,
-            "text": {}
-          },
-          "pluginVersion": "7.5.17",
-          "repeatDirection": "h",
-          "repeatIteration": 1705107864294,
-          "repeatPanelId": 10,
-          "scopedVars": {
-            "ModelID": {
-              "selected": false,
-              "text": "ibm-granite/granite-3.1-8b-instruct",
-              "value": "ibm-granite/granite-3.1-8b-instruct"
-            }
-          },
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "(sum((feedback_stars_total{namespace=\"$namespace\", stars=\"1\", model_id=\"${ModelID:raw}\"} or on() vector(0))* 1) + sum((feedback_stars_total{namespace=\"$namespace\", stars=\"2\", model_id=\"${ModelID:raw}\"} or on() vector(0)) * 2) +\nsum((feedback_stars_total{namespace=\"$namespace\", stars=\"3\", model_id=\"${ModelID:raw}\"} or on() vector(0)) * 3) + sum((feedback_stars_total{namespace=\"$namespace\", stars=\"4\", model_id=\"${ModelID:raw}\"} or on() vector(0)) * 4) +\nsum((feedback_stars_total{namespace=\"$namespace\", stars=\"5\", model_id=\"${ModelID:raw}\"} or on() vector(0)) * 5)) \n/\n(sum(feedback_stars_total{namespace=\"$namespace\", stars=\"1\", model_id=\"${ModelID:raw}\"} or on() vector(0)) + sum(feedback_stars_total{namespace=\"$namespace\", stars=\"2\", model_id=\"${ModelID:raw}\"} or on() vector(0)) + sum(feedback_stars_total{namespace=\"$namespace\", stars=\"3\", model_id=\"${ModelID:raw}\"} or on() vector(0)) + sum(feedback_stars_total{namespace=\"$namespace\", stars=\"4\", model_id=\"${ModelID:raw}\"} or on() vector(0)) + sum(feedback_stars_total{namespace=\"$namespace\", stars=\"5\", model_id=\"${ModelID:raw}\"} or on() vector(0)))",
-              "format": "time_series",
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{model_id}}",
-              "refId": "A"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "$ModelID - AVERAGE RATING",
-          "type": "gauge"
-        },
-        {
-          "datasource": null,
+          "datasource": "Prometheus",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -368,16 +215,18 @@ spec:
           },
           "gridPos": {
             "h": 7,
-            "w": 12,
+            "w": 24,
             "x": 0,
             "y": 17
           },
           "id": 12,
+          "maxPerRow": 2,
           "options": {
             "colorMode": "value",
             "graphMode": "area",
             "justifyMode": "auto",
             "orientation": "auto",
+            "percentChangeColorMode": "standard",
             "reduceOptions": {
               "calcs": [
                 "lastNotNull"
@@ -385,20 +234,17 @@ spec:
               "fields": "",
               "values": false
             },
+            "showPercentChange": false,
             "text": {},
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "7.5.17",
+          "pluginVersion": "11.3.0",
           "repeat": "ModelID",
-          "scopedVars": {
-            "ModelID": {
-              "selected": false,
-              "text": "mistral-community/Mistral-7B-v0.2",
-              "value": "mistral-community/Mistral-7B-v0.2"
-            }
-          },
+          "repeatDirection": "h",
           "targets": [
             {
+              "datasource": "Prometheus",
               "exemplar": true,
               "expr": "model_usage_total{model_id=\"${ModelID:raw}\",namespace=\"$namespace\"}",
               "instant": false,
@@ -407,101 +253,35 @@ spec:
               "refId": "A"
             }
           ],
-          "timeFrom": null,
-          "timeShift": null,
           "title": "$ModelID - MODEL USAGE",
-          "transformations": [],
           "transparent": true,
           "type": "stat"
         },
         {
-          "datasource": null,
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 17
-          },
-          "id": 23,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "7.5.17",
-          "repeatIteration": 1705107864294,
-          "repeatPanelId": 12,
-          "scopedVars": {
-            "ModelID": {
-              "selected": false,
-              "text": "ibm-granite/granite-3.1-8b-instruct",
-              "value": "ibm-granite/granite-3.1-8b-instruct"
-            }
-          },
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "model_usage_total{model_id=\"${ModelID:raw}\",namespace=\"$namespace\"}",
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{model_id}}",
-              "refId": "A"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "$ModelID - MODEL USAGE",
-          "transformations": [],
-          "transparent": true,
-          "type": "stat"
-        },
-        {
-          "datasource": null,
+          "datasource": "Prometheus",
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
                 "hideFrom": {
                   "graph": false,
                   "legend": false,
-                  "tooltip": false
+                  "tooltip": false,
+                  "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -509,7 +289,14 @@ spec:
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
@@ -536,20 +323,24 @@ spec:
             "y": 24
           },
           "id": 14,
+          "maxPerRow": 2,
           "options": {
             "graph": {},
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
-            "tooltipOptions": {
-              "mode": "single"
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
             }
           },
-          "pluginVersion": "7.5.17",
+          "pluginVersion": "11.3.0",
           "targets": [
             {
+              "datasource": "Prometheus",
               "exemplar": true,
               "expr": "request_duration_seconds{namespace=\"${namespace}\"}",
               "interval": "",
@@ -557,34 +348,25 @@ spec:
               "refId": "A"
             }
           ],
-          "timeFrom": null,
-          "timeShift": null,
           "title": "RESPONSE TIME  UI -> INFERENCE SERVER",
           "transparent": true,
           "type": "timeseries"
         }
       ],
+      "preload": false,
       "refresh": "5s",
-      "schemaVersion": 27,
-      "style": "dark",
+      "schemaVersion": 40,
       "tags": [],
       "templating": {
         "list": [
           {
-            "allValue": null,
             "current": {
-              "selected": false,
-              "text": "tgis-llm-demo",
-              "value": "tgis-llm-demo"
+              "text": "rag-llm",
+              "value": "rag-llm"
             },
-            "datasource": null,
+            "datasource": "Prometheus",
             "definition": "label_values(namespace)",
-            "description": null,
-            "error": null,
-            "hide": 0,
             "includeAll": false,
-            "label": null,
-            "multi": false,
             "name": "namespace",
             "options": [],
             "query": {
@@ -593,49 +375,30 @@ spec:
             },
             "refresh": 1,
             "regex": "",
-            "skipUrlSync": false,
-            "sort": 0,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
           },
           {
-            "allValue": null,
             "current": {
-              "selected": true,
-              "tags": [],
               "text": [
-                "All"
+                "ibm-granite-instruct"
               ],
               "value": [
-                "$__all"
+                "ibm-granite-instruct"
               ]
             },
-            "datasource": null,
             "definition": "label_values(model_id)",
-            "description": null,
-            "error": null,
-            "hide": 0,
             "includeAll": true,
-            "label": null,
             "multi": true,
             "name": "ModelID",
             "options": [],
             "query": {
+              "qryType": 1,
               "query": "label_values(model_id)",
-              "refId": "StandardVariableQuery"
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
             "refresh": 1,
             "regex": "",
-            "skipUrlSync": false,
-            "sort": 0,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
           }
         ]
       },
@@ -647,5 +410,6 @@ spec:
       "timezone": "",
       "title": "MODEL FEEDBACK/RATING",
       "uid": "HtUdEp4Ik",
-      "version": 3
+      "version": 1,
+      "weekStart": ""
     }

--- a/charts/all/llm-serving-service/templates/accelerator-profile.yaml
+++ b/charts/all/llm-serving-service/templates/accelerator-profile.yaml
@@ -3,8 +3,6 @@ kind: AcceleratorProfile
 metadata:
   name: nvidia-gpu
   namespace: redhat-ods-applications
-  annotations:
-    argocd.argoproj.io/sync-wave: "40"
 spec:
   displayName: NVIDIA GPU
   enabled: true

--- a/charts/all/llm-serving-service/templates/inference-service.yaml
+++ b/charts/all/llm-serving-service/templates/inference-service.yaml
@@ -12,6 +12,8 @@ metadata:
     opendatahub.io/dashboard: 'true'
 spec:
   predictor:
+    annotations:
+      serving.knative.dev/progress-deadline: 30m
     maxReplicas: 1
     minReplicas: 1
     model:

--- a/charts/all/rag-llm/charts/elastic/.helmignore
+++ b/charts/all/rag-llm/charts/elastic/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/all/rag-llm/charts/elastic/Chart.yaml
+++ b/charts/all/rag-llm/charts/elastic/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: elastic
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/all/rag-llm/charts/elastic/templates/_helpers.tpl
+++ b/charts/all/rag-llm/charts/elastic/templates/_helpers.tpl
@@ -1,0 +1,76 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "elastic.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "elastic.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "elastic.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "elastic.labels" -}}
+helm.sh/chart: {{ include "elastic.chart" . }}
+{{ include "elastic.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "elastic.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "elastic.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "elastic.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "elastic.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Extracts everything after the slash and removes everything after the last dash.
+Input example: value/value-value-02
+Output: value-value
+This is the required format for servingRuntime
+*/}}
+{{- define "extractModelId" -}}
+  {{- $input := . -}}
+  {{- $afterSlash := regexReplaceAll "^.*/" $input "" -}}
+  {{- $beforeLastDash := regexReplaceAll "-[^-]*$" $afterSlash "" -}}
+  {{- $beforeLastDash -}}
+{{- end -}}

--- a/charts/all/rag-llm/charts/elastic/templates/elasticsearch.yaml
+++ b/charts/all/rag-llm/charts/elastic/templates/elasticsearch.yaml
@@ -1,0 +1,23 @@
+{{- if eq .Values.global.db.type "ELASTIC" }}
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: es-vectordb
+spec:
+  auth: {}
+  http:
+    tls:
+      selfSignedCertificate:
+        disabled: true
+  nodeSets:
+    - config:
+        node.store.allow_mmap: false
+      count: 1
+      name: default
+      podTemplate:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containers: null
+  version: {{ .Values.elasticVersion }}
+{{- end }}

--- a/charts/all/rag-llm/charts/elastic/values.yaml
+++ b/charts/all/rag-llm/charts/elastic/values.yaml
@@ -1,0 +1,6 @@
+# Default values for elastic.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Define Elastic Search cluster version
+elasticVersion: "8.15.0"

--- a/charts/all/rag-llm/templates/deployment.yaml
+++ b/charts/all/rag-llm/templates/deployment.yaml
@@ -88,6 +88,21 @@ spec:
             - name: PGVECTOR_COLLECTION_NAME
               value: {{ .Values.global.db.index }}
         {{- end }}
+        {{- if eq .Values.global.db.type "ELASTIC" }}
+            - name: DB_TYPE
+              value: "ELASTIC"
+            - name: ELASTIC_INDEX
+              value: {{ .Values.global.db.index }}
+            - name: ELASTIC_URL
+              value: "http://es-vectordb-es-http:9200"
+            - name: ELASTIC_USER
+              value: "elastic"
+            - name: ELASTIC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: es-vectordb-es-elastic-user
+                  key: elastic
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/all/rag-llm/templates/populate-vectordb-job.yaml
+++ b/charts/all/rag-llm/templates/populate-vectordb-job.yaml
@@ -46,7 +46,7 @@ spec:
         - name: REDIS_SCHEMA
           value: redis_schema.yaml
       {{- end }}
-     {{- if eq .Values.global.db.type "EDB" }}
+      {{- if eq .Values.global.db.type "EDB" }}
         - name: DB_TYPE
           value: "PGVECTOR"
         - name: DB_USERNAME
@@ -83,6 +83,21 @@ spec:
           value: 'postgresql+psycopg://$(DB_USERNAME):$(DB_PASS)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)'
         - name: PGVECTOR_COLLECTION_NAME
           value: {{ .Values.global.db.index }}
+      {{- end }}
+      {{- if eq .Values.global.db.type "ELASTIC" }}
+        - name: DB_TYPE
+          value: "ELASTIC"
+        - name: ELASTIC_INDEX
+          value: {{ .Values.global.db.index }}
+        - name: ELASTIC_URL
+          value: "http://es-vectordb-es-http:9200"
+        - name: ELASTIC_USER
+          value: "elastic"
+        - name: ELASTIC_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: es-vectordb-es-elastic-user
+              key: elastic
         {{- end }}
         command: ["/usr/bin/bash", "/app/entrypoint.sh"]
         {{- if .Values.populateDbJob.args }}

--- a/charts/all/rag-llm/values.yaml
+++ b/charts/all/rag-llm/values.yaml
@@ -17,7 +17,7 @@ image:
   repository: 'quay.io/ecosystem-appeng/rag-llm-ui'
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.0"
+  tag: "1.1"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/values-global.yaml
+++ b/values-global.yaml
@@ -5,7 +5,7 @@ global:
     useCSV: false
     syncPolicy: Automatic
     installPlanApproval: Automatic
-# Possible value for db.type = [REDIS, EDB]
+# Possible value for db.type = [REDIS, EDB, ELASTIC]
   db:
     index: docs
     type: EDB

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -11,6 +11,9 @@ clusterGroup:
         operatorGroup: true
         targetNamespaces: []
     - rag-llm:
+        operatorGroup: true
+        targetNamespaces: 
+          - rag-llm
         labels:
           opendatahub.io/dashboard: "true"
           modelmesh-enabled: 'false'
@@ -35,6 +38,12 @@ clusterGroup:
       namespace: openshift-operators
       channel: stable-v1.23
       source: certified-operators
+    elastic:
+      name: elasticsearch-eck-operator-certified
+      namespace: rag-llm
+      channel: stable
+      source: certified-operators
+      sourceNamespace: openshift-marketplace
     serverless:
       name: serverless-operator
       namespace: openshift-serverless


### PR DESCRIPTION
Changes to helm charts to add Elastic as one of the supported vector dbs. Also includes fixes to grafana dashboards to eliminate duplication for some of the tiles